### PR TITLE
Typo

### DIFF
--- a/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
+++ b/src/main/java/net/blerf/ftl/parser/SavedGameParser.java
@@ -2898,7 +2898,7 @@ System.err.println(String.format("Projectile: @%d", in.getChannel().position()))
 			extendedSystemInfoList.add( info );
 		}
 
-		public void setExtendedSystemInfoList( List<ExtendedSystemInfo> iotaList ) { this.extendedSystemInfoList = extendedSystemInfoList; }
+		public void setExtendedSystemInfoList( List<ExtendedSystemInfo> iotaList ) { this.extendedSystemInfoList = iotaList; }
 		public List<ExtendedSystemInfo> getExtendedSystemInfoList() { return extendedSystemInfoList; }
 
 		public <T extends ExtendedSystemInfo> List<T> getExtendedSystemInfoList( Class<T> infoClass ) {


### PR DESCRIPTION
setExtendedSystemInfoList was just setting it's extendedSystemInfoList to itself instead of the new var.

I really don't understand github yet, but hopefully this was the right way to do this. Thanks!
