### PR TITLE
Add JAXB Dependencies to POM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ Desktop.ini
 # IdeaJ
 *.idea
 *.iml
+
+# Application state
+ftl-editor-log.txt
+ftl-editor.cfg

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,19 @@
 			<artifactId>jcommander</artifactId>
 			<version>1.48</version>  <!-- Since 1.55, requires Java 7. Since 1.58, Java 8. -->
 		</dependency>
+		<!-- API, java.xml.bind module -->
+		<dependency>
+		    <groupId>jakarta.xml.bind</groupId>
+		    <artifactId>jakarta.xml.bind-api</artifactId>
+		    <version>2.3.2</version>
+		</dependency>
+		
+		<!-- Runtime, com.sun.xml.bind module -->
+		<dependency>
+		    <groupId>org.glassfish.jaxb</groupId>
+		    <artifactId>jaxb-runtime</artifactId>
+		    <version>2.3.2</version>
+		</dependency>
 	</dependencies>
   
 	<build>


### PR DESCRIPTION
This likely isn't enough to cover all the bases, but from my tests, it looks like it builds successfully using modern Java versions.
Also added a couple .gitignore entries because my Git client was harassing me.