### PR TITLE
Show Type-B ship icons

### DIFF
--- a/src/main/java/net/blerf/ftl/ui/IconCycleButton.java
+++ b/src/main/java/net/blerf/ftl/ui/IconCycleButton.java
@@ -15,10 +15,12 @@ public class IconCycleButton extends JButton implements ActionListener {
 
 	private Icon[] icons;
 	private int state = 0;
+	private boolean disabled;
 
 
 	public IconCycleButton( Icon[] icons ) {
 		this.icons = icons;
+		this.disabled = false;
 		this.setBorder( BorderFactory.createEmptyBorder( 2, 4, 2, 4 ) );
 		this.setFocusPainted( true );
 		this.setContentAreaFilled( false );
@@ -35,9 +37,15 @@ public class IconCycleButton extends JButton implements ActionListener {
 	public int getSelectedState() {
 		return state;
 	}
+	
+	public void setDisabled(boolean d) {
+		disabled = d;
+	}
 
 	@Override
 	public void actionPerformed( ActionEvent e ) {
-		setSelectedState( (state+1) % icons.length );
+		if(!disabled) {
+			setSelectedState( (state+1) % icons.length );
+		}
 	}
 }

--- a/src/main/java/net/blerf/ftl/ui/ProfileShipUnlockPanel.java
+++ b/src/main/java/net/blerf/ftl/ui/ProfileShipUnlockPanel.java
@@ -118,7 +118,8 @@ public class ProfileShipUnlockPanel extends JPanel implements ActionListener {
 		panel.add( shipABox );
 
 		if ( variantBShip != null ) {
-			IconCycleButton shipBBox = ImageUtilities.createDummyCycleButton();
+			IconCycleButton shipBBox = ImageUtilities.createCycleButton("img/ship/"+ variantBShip.getGraphicsBaseName() + "_base.png", false);
+			shipBBox.setDisabled(true);
 			shipBBox.addMouseListener( new StatusbarMouseListener( frame, "Type-B: "+ variantBShip.getName().getTextValue() +" (To unlock, choose two ship achievements below.)" ) );
 			panel.add( shipBBox );
 		}


### PR DESCRIPTION
This one is just for fun. It felt weird seeing the gaps in the Ship Unlock Panel, so I added the Type-B ships back as disabled buttons.

Commit description:
Of course, the initial reason these were disabled was to prevent breaking the save due to the achievement-based nature of Type B unlocks, so I added a property to disable the buttons from being clicked.